### PR TITLE
Add Contents and Config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,9 @@ var tsSources = [
     "kernel",
     "session",
     "utils",
-    "serialize"
+    "serialize",
+    "config",
+    "contents"
 ].map(function(name) {return "./src/" + name + ".ts"; });
 
 

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -540,6 +540,30 @@ paths:
             properties:
               kernelspec:
                 $ref: '#/definitions/KernelSpec'
+  /config/{section_name}:
+    get:
+      summary: Get a configuration section by name
+      tags:
+        - config
+      responses:
+        200:
+          description: Configuration object
+          schema:
+            type: object
+    patch:
+      summary: Update a configuration section by name
+      tags:
+        - config
+      parameters:
+        - name: configuration
+          in: body
+          schema:
+            type: object
+      responses:
+        200:
+          description: Configuration object
+          schema:
+            type: object
 
 definitions:
   KernelSpec:
@@ -697,3 +721,6 @@ definitions:
         type: string
         description: Last modified timestamp
         format: dateTime
+  Config:
+    description: A configuration object.
+    type: object

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -66,7 +66,7 @@ paths:
             - base64
         - name: content
           in: query
-          description: return content (0 for no content, 1 for return content)
+          description: Return content (0 for no content, 1 for return content)
           type: integer
       responses:
         404:
@@ -190,11 +190,11 @@ paths:
               type:
                 type: string
                 in: query
-                description: One of ('notebook', 'file', 'directory')
+                description: Path type ('notebook', 'file', 'directory')
               format:
                 type: string
                 in: query
-                description: One of ('json', 'text', 'base64')
+                description: File format ('json', 'text', 'base64')
               content:
                 type: string
                 description: The actual body of the document (excluding 'type=directory')

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -33,6 +33,12 @@ parameters:
     in: path
     description: file path
     type: string
+  checkpoint_id:
+    name: checkpoint_id
+    required: true
+    in: path
+    description: Checkpoint id for a file
+    type: string
 
 paths:
   /contents/{path}:
@@ -227,6 +233,32 @@ paths:
               reason:
                 type: string
                 description: Explanation of error reason
+  /contents/{path}/checkpoints/{checkpoint_id}:
+    post:
+      summary: Restore a file to a particular checkpointed state
+      tags:
+        - contents
+      responses:
+        204:
+          description: Checkpoint created
+        400:
+          description: Bad request
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
+    delete:
+      summary: Delete a checkpoint
+      tags:
+        - contents
+      responses:
+        204:
+          description: Checkpoint deleted
   /sessions/{session}:
     parameters:
       - $ref: '#/parameters/session'

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -272,7 +272,7 @@ paths:
           description: Model key error
     post:
       summary: Create a new checkpoint for a file
-      description: Create a new checkpoint with the current state of a file. With the default FileContentsManager, only one checkpoint is supported, so creating new checkpoints clobbers existing ones.
+      description: "Create a new checkpoint with the current state of a file. With the default FileContentsManager, only one checkpoint is supported, so creating new checkpoints clobbers existing ones."
       tags:
         - contents
       responses:
@@ -337,7 +337,7 @@ paths:
           schema:
             $ref: '#/definitions/Session'
     patch:
-      summary: This can be used to rename the notebook, or move it to a new directory.
+      summary: "This can be used to rename the notebook, or move it to a new directory."
       tags:
         - sessions
       parameters:
@@ -369,7 +369,7 @@ paths:
         204:
           description: Session (and kernel) were deleted
         410:
-          description: Kernel was deleted before the session, and the session was *not* deleted (TODO - check to make sure session wasn't deleted)
+          description: "Kernel was deleted before the session, and the session was *not* deleted (TODO - check to make sure session wasn't deleted)"
   /sessions:
     get:
       summary: List available sessions
@@ -383,7 +383,7 @@ paths:
             items:
               $ref: '#/definitions/Session'
     post:
-      summary: Create a new session, or return an existing session if a session for the notebook path already exists
+      summary: "Create a new session, or return an existing session if a session for the notebook path already exists"
       tags:
         - sessions
       parameters:
@@ -405,7 +405,7 @@ paths:
                 properties:
                   name:
                     type: string
-                    description: Kernel spec name, defaults to default kernel spec
+                    description: "Kernel spec name, defaults to default kernel spec"
       responses:
         201:
           description: Session created or returned
@@ -596,12 +596,12 @@ definitions:
         description: The programming language which this kernel runs. This will be stored in notebook metadata.
       argv:
         type: array
-        description: A list of command line arguments used to start the kernel. The text `{connection_file}` in any argument will be replaced with the path to the connection file.
+        description: "A list of command line arguments used to start the kernel. The text `{connection_file}` in any argument will be replaced with the path to the connection file."
         items:
           type: string
       display_name:
         type: string
-        description: The kernel's name as it should be displayed in the UI. Unlike the kernel name used in the API, this can contain arbitrary unicode characters.
+        description: "The kernel's name as it should be displayed in the UI. Unlike the kernel name used in the API, this can contain arbitrary unicode characters."
       codemirror_mode:
         type: string
         description: Codemirror mode.  Can be a string *or* an valid Codemirror mode object.  This defaults to the string from the `language` property.
@@ -655,7 +655,7 @@ definitions:
       kernel:
         $ref: '#/definitions/Kernel'
   Contents:
-    description: A contents object.  The content and format keys may be null if content is not contained.  If type is 'file', then the mimetype will be null.
+    description: "A contents object.  The content and format keys may be null if content is not contained.  If type is 'file', then the mimetype will be null."
     type: object
     required:
       - type
@@ -670,7 +670,7 @@ definitions:
     properties:
       name:
         type: string
-        description: Name of file or directory, equivalent to the last part of the path
+        description: "Name of file or directory, equivalent to the last part of the path"
       path:
         type: string
         description: Full path for file or directory
@@ -694,10 +694,10 @@ definitions:
         format: dateTime
       mimetype:
         type: string
-        description: The mimetype of a file.  If content is not null, and type is 'file', this will contain the mimetype of the file, otherwise this will be null.
+        description: "The mimetype of a file.  If content is not null, and type is 'file', this will contain the mimetype of the file, otherwise this will be null."
       content:
         type: string
-        description: The content, if requested (otherwise null).  Will be an array if type is 'directory'
+        description: "The content, if requested (otherwise null).  Will be an array if type is 'directory'"
       format:
         type: string
         description: Format of content (one of null, 'text', 'base64', 'json')

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -182,7 +182,7 @@ paths:
             properties:
               name:
                 type: string
-                description: The new filename (`my notebook.ipynb`), if changed
+                description: The new filename if changed
               path:
                 type: string
                 format: path

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -527,39 +527,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/KernelSpec'
-  /kernelspecs/{kernel}:
-    parameters:
-      - $ref: '#/parameters/kernel'
-    get:
-      summary: Kernel information
-      tags:
-        - kernelspecs
-      responses:
-        200:
-          description: The contents of kernel.json
-          schema:
-            $ref: '#/definitions/KernelSpec'
-        404:
-          description: Kernel spec not found
-  /kernelspecs/{kernel}/{filename}:
-    get:
-      summary: Retrieve a file from the kernel directory
-      tags:
-        - kernelspecs
-      parameters:
-        - name: kernel
-          in: path
-          description: Kernel uuid
-          type: string
-          required: true
-        - name: filename
-          in: path
-          description: filename
-          type: string
-          required: true
-      responses:
-        200:
-          description: file
 
 definitions:
   KernelSpec:

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -46,7 +46,7 @@ paths:
       - $ref: '#/parameters/path'
     get:
       summary: Get contents of file or directory
-      description: A client can optionally specify a type and/or format argument via URL parameter. When given, the Contents service shall return a model in the requested type and/or format. If the request cannot be satisfied, e.g. type=text is requested, but the file is binary, then the request shall fail with 400 and have a JSON response containing a 'reason' field, with the value 'bad format' or 'bad type', depending on what was requested.
+      description: "A client can optionally specify a type and/or format argument via URL parameter. When given, the Contents service shall return a model in the requested type and/or format. If the request cannot be satisfied, e.g. type=text is requested, but the file is binary, then the request shall fail with 400 and have a JSON response containing a 'reason' field, with the value 'bad format' or 'bad type', depending on what was requested."
       tags:
         - contents
       parameters:
@@ -59,14 +59,14 @@ paths:
             - directory
         - name: format
           in: query
-          description: How file content should be returned ('text', 'base64')
+          description: "How file content should be returned ('text', 'base64')"
           type: string
           enum:
             - text
             - base64
         - name: content
           in: query
-          description: Return content (0 for no content, 1 for return content)
+          description: "Return content (0 for no content, 1 for return content)"
           type: integer
       responses:
         404:
@@ -455,11 +455,13 @@ paths:
       responses:
         201:
           description: Kernel started
+          schema:
+            $ref: '#/definitions/Kernel'
           headers:
             Location:
               description: Model for started kernel
-              schema:
-                $ref: '#/definitions/Kernel'
+              type: string
+              format: url
   /kernels/{kernel}:
     parameters:
       - $ref: '#/parameters/kernel'

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -197,7 +197,7 @@ paths:
                 description: File format ('json', 'text', 'base64')
               content:
                 type: string
-                description: The actual body of the document (excluding 'type=directory')
+                description: The actual body of the document, excluding 'type=directory'
       responses:
         201:
           description: Path updated

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -462,7 +462,7 @@ paths:
               description: Model for started kernel
               type: string
               format: url
-  /kernels/{kernel}:
+  /kernels/{kernel_id}:
     parameters:
       - $ref: '#/parameters/kernel'
     get:
@@ -481,7 +481,7 @@ paths:
       responses:
         204:
           description: Kernel deleted
-  /kernels/{kernel}/interrupt:
+  /kernels/{kernel_id}/interrupt:
     parameters:
       - $ref: '#/parameters/kernel'
     post:
@@ -491,7 +491,7 @@ paths:
       responses:
         204:
           description: Kernel interrupted
-  /kernels/{kernel}/restart:
+  /kernels/{kernel_id}/restart:
     parameters:
       - $ref: '#/parameters/kernel'
     post:
@@ -527,6 +527,19 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/KernelSpec'
+  /kernelspecs/{spec_name}:
+    get:
+      summary: Get a kernel spec by name
+      tags:
+        - kernelspecs
+      responses:
+        200:
+          description: Kernel spec
+          schema:
+            type: object
+            properties:
+              kernelspec:
+                $ref: '#/definitions/KernelSpec'
 
 definitions:
   KernelSpec:

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -95,7 +95,7 @@ paths:
           description: Model key error
     post:
       summary: Create a new file in the specified path
-      description: A POST to /api/contents/path creates a New untitled, empty file or directory. A POST to /api/contents/path with body {"copy_from", "/path/to/OtherNotebook.ipynb"} creates a new copy of OtherNotebook in path.
+      description: 'A POST to /api/contents/path creates a New untitled, empty file or directory. A POST to /api/contents/path with body {"copy_from": "/path/to/OtherNotebook.ipynb"} creates a new copy of OtherNotebook in path.''
       tags:
         - contents
       parameters:
@@ -172,8 +172,8 @@ paths:
                 type: string
                 description: Explanation of error reason
     put:
-      summary: Save an existing file
-      description: Update an existing file in-place. This is how standard saves are performed.  Returns the updated model without content.
+      summary: Save or upload file.
+      description: "Saves the file in the location specified by name and path.  PUT is very similar to POST, but the requester specifies the name, whereas with POST, the server picks the name."
       tags:
         - contents
       parameters:
@@ -212,7 +212,7 @@ paths:
           description: Path created
           headers:
             Location:
-              description: Updated URL for the file or directory
+              description: URL for the file or directory
               type: string
               format: url
           schema:

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -95,7 +95,7 @@ paths:
           description: Model key error
     post:
       summary: Create a new file in the specified path
-      description: 'A POST to /api/contents/path creates a New untitled, empty file or directory. A POST to /api/contents/path with body {"copy_from": "/path/to/OtherNotebook.ipynb"} creates a new copy of OtherNotebook in path.''
+      description: 'A POST to /api/contents/path creates a New untitled, empty file or directory. A POST to /api/contents/path with body {"copy_from": "/path/to/OtherNotebook.ipynb"} creates a new copy of OtherNotebook in path.'
       tags:
         - contents
       parameters:

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -527,19 +527,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/KernelSpec'
-  /kernelspecs/{spec_name}:
-    get:
-      summary: Get a kernel spec by name
-      tags:
-        - kernelspecs
-      responses:
-        200:
-          description: Kernel spec
-          schema:
-            type: object
-            properties:
-              kernelspec:
-                $ref: '#/definitions/KernelSpec'
   /config/{section_name}:
     get:
       summary: Get a configuration section by name

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -115,6 +115,8 @@ paths:
               description: URL for the new file
               type: string
               format: url
+          schema:
+            $ref: '#/definitions/Contents'
         404:
           description: No item found
         400:
@@ -152,6 +154,60 @@ paths:
               description: Updated URL for the file or directory
               type: string
               format: url
+          schema:
+            $ref: '#/definitions/Contents'
+        400:
+          description: No data provided
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
+    put:
+      summary: Save an existing file
+      description: Update an existing file in-place. This is how standard saves are performed.  Returns the updated model without content.
+      tags:
+        - contents
+      parameters:
+        - name: model
+          in: body
+          required: true
+          description: New path for file or directory
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The new filename (`my notebook.ipynb`), if changed
+              path:
+                type: string
+                format: path
+                description: New path for file or directory
+              type:
+                type: string
+                in: query
+                description: One of ('notebook', 'file', 'directory')
+              format:
+                type: string
+                in: query
+                description: One of ('json', 'text', 'base64')
+              content:
+                type: string
+                description: The actual body of the document (excluding 'type=directory')
+      responses:
+        201:
+          description: Path updated
+          headers:
+            Location:
+              description: Updated URL for the file or directory
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/Contents'
         400:
           description: No data provided
           schema:

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -185,19 +185,16 @@ paths:
                 description: The new filename if changed
               path:
                 type: string
-                format: path
                 description: New path for file or directory
               type:
                 type: string
-                in: query
-                description: Path type ('notebook', 'file', 'directory')
+                description: Path dtype ('notebook', 'file', 'directory')
               format:
                 type: string
-                in: query
                 description: File format ('json', 'text', 'base64')
               content:
                 type: string
-                description: The actual body of the document, excluding 'type=directory'
+                description: The actual body of the document excluding directory type
       responses:
         201:
           description: Path updated

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -95,7 +95,7 @@ paths:
           description: Model key error
     post:
       summary: Create a new file in the specified path
-      description: 'A POST to /api/contents/path creates a New untitled, empty file or directory. A POST to /api/contents/path with body {"copy_from": "/path/to/OtherNotebook.ipynb"} creates a new copy of OtherNotebook in path.'
+      description: "A POST to /api/contents/path creates a New untitled, empty file or directory. A POST to /api/contents/path with body {'copy_from': '/path/to/OtherNotebook.ipynb'} creates a new copy of OtherNotebook in path."
       tags:
         - contents
       parameters:

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -169,6 +169,64 @@ paths:
               description: URL for the removed file
               type: string
               format: url
+  /contents/{path}/checkpoints:
+    parameters:
+      - $ref: '#/parameters/path'
+    get:
+      summary: Get a list of checkpoints for a file
+      description: List checkpoints for a given file. There will typically be zero or one results.
+      tags:
+        - contents
+      responses:
+        404:
+          description: No item found
+        400:
+          description: Bad request
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
+        200:
+          description: List of checkpoints for a file
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Checkpoints'
+        500:
+          description: Model key error
+    post:
+      summary: Create a new checkpoint for a file
+      description: Create a new checkpoint with the current state of a file. With the default FileContentsManager, only one checkpoint is supported, so creating new checkpoints clobbers existing ones.
+      tags:
+        - contents
+      responses:
+        201:
+          description: Checkpoint created
+          headers:
+            Location:
+              description: URL for the checkpoint
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/Checkpoints'
+        404:
+          description: No item found
+        400:
+          description: Bad request
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
   /sessions/{session}:
     parameters:
       - $ref: '#/parameters/session'
@@ -546,3 +604,17 @@ definitions:
       format:
         type: string
         description: Format of content (one of null, 'text', 'base64', 'json')
+  Checkpoints:
+    description: A checkpoint object.
+    type: object
+    required:
+      - id
+      - last_modified
+    properties:
+      id:
+        type: string
+        description: Unique id for the checkpoint.
+      last_modified:
+        type: string
+        description: Last modified timestamp
+        format: dateTime

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -457,9 +457,9 @@ paths:
           description: Kernel started
           headers:
             Location:
-              description: URL for kernel commands
-              type: string
-              format: url
+              description: Model for started kernel
+              schema:
+                $ref: '#/definitions/Kernel'
   /kernels/{kernel}:
     parameters:
       - $ref: '#/parameters/kernel'

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -107,6 +107,10 @@ paths:
             properties:
               copy_from:
                 type: string
+              ext:
+                type: string
+              type:
+                type: string
       responses:
         201:
           description: File created
@@ -135,7 +139,7 @@ paths:
       tags:
         - contents
       parameters:
-        - name: model
+        - name: path
           in: body
           required: true
           description: New path for file or directory.
@@ -175,7 +179,6 @@ paths:
       parameters:
         - name: model
           in: body
-          required: true
           description: New path for file or directory
           schema:
             type: object
@@ -196,8 +199,17 @@ paths:
                 type: string
                 description: The actual body of the document excluding directory type
       responses:
+        200:
+          description: File saved
+          headers:
+            Location:
+              description: Updated URL for the file or directory
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/Contents'
         201:
-          description: Path updated
+          description: Path created
           headers:
             Location:
               description: Updated URL for the file or directory

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -77,7 +77,7 @@ paths:
                 type: string
                 description: Explanation of error reason
         200:
-          description: Contents of file or directory.
+          description: Contents of file or directory
           headers:
             Last-Modified:
               description: Last modified date for file
@@ -95,7 +95,7 @@ paths:
       parameters:
         - name: model
           in: body
-          description: 
+          description: Path of file to copy
           schema:
             type: object
             properties:
@@ -106,13 +106,48 @@ paths:
           description: File created
           headers:
             Location:
-              description: URL for the new file.
+              description: URL for the new file
               type: string
               format: url
         404:
           description: No item found
         400:
           description: Bad request
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
+    patch:
+      summary: Rename a file or directory without re-uploading content
+      tags:
+        - contents
+      parameters:
+        - name: model
+          in: body
+          required: true
+          description: New path for file or directory.
+          schema:
+            type: object
+            properties:
+              path:
+                type: string
+                format: path
+                description: New path for file or directory.
+      responses:
+        200:
+          description: Path updated
+          headers:
+            Location:
+              description: Updated URL for the file or directory.
+              type: string
+              format: url
+        400:
+          description: No data provided
           schema:
             type: object
             properties:

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -1,0 +1,501 @@
+swagger: '2.0'
+info:
+  title: Jupyter Notebook API
+  description: Notebook API
+  version: "4"
+  contact:
+    name: Jupyter Project
+    url: jupyter.org
+# will be prefixed to all paths
+basePath: /api
+produces:
+  - application/json
+consumes:
+  - application/json
+parameters:
+  kernel:
+    name: kernel
+    required: true
+    in: path
+    description: kernel uuid
+    type: string
+    format: uuid
+  session:
+    name: session
+    required: true
+    in: path
+    description: session uuid
+    type: string
+    format: uuid
+  path:
+    name: path
+    required: true
+    in: path
+    description: file path
+    type: string
+
+paths:
+  /contents/{path}:
+    parameters:
+      - $ref: '#/parameters/path'
+    get:
+      summary: Get contents of file or directory
+      description: A client can optionally specify a type and/or format argument via URL parameter. When given, the Contents service shall return a model in the requested type and/or format. If the request cannot be satisfied, e.g. type=text is requested, but the file is binary, then the request shall fail with 400 and have a JSON response containing a 'reason' field, with the value 'bad format' or 'bad type', depending on what was requested.
+      tags:
+        - contents
+      parameters:
+        - name: type
+          in: query
+          description: File type ('file', 'directory')
+          type: string
+          enum:
+            - file
+            - directory
+        - name: format
+          in: query
+          description: How file content should be returned ('text', 'base64')
+          type: string
+          enum:
+            - text
+            - base64
+        - name: content
+          in: query
+          description: return content (0 for no content, 1 for return content)
+          type: integer
+      responses:
+        404:
+          description: No item found
+        400:
+          description: Bad request
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
+        200:
+          description: Contents of file or directory.
+          headers:
+            Last-Modified:
+              description: Last modified date for file
+              type: string
+              format: dateTime
+          schema:
+            $ref: '#/definitions/Contents'
+        500:
+          description: Model key error
+    post:
+      summary: Create a new file in the specified path
+      description: A POST to /api/contents/path creates a New untitled, empty file or directory. A POST to /api/contents/path with body {"copy_from", "/path/to/OtherNotebook.ipynb"} creates a new copy of OtherNotebook in path.
+      tags:
+        - contents
+      parameters:
+        - name: model
+          in: body
+          description: 
+          schema:
+            type: object
+            properties:
+              copy_from:
+                type: string
+      responses:
+        201:
+          description: File created
+          headers:
+            Location:
+              description: URL for the new file.
+              type: string
+              format: url
+        404:
+          description: No item found
+        400:
+          description: Bad request
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error condition
+              reason:
+                type: string
+                description: Explanation of error reason
+  /sessions/{session}:
+    parameters:
+      - $ref: '#/parameters/session'
+    get:
+      summary: Get session
+      tags:
+        - sessions
+      responses:
+        200:
+          description: Session
+          schema:
+            $ref: '#/definitions/Session'
+    patch:
+      summary: This can be used to rename the notebook, or move it to a new directory.
+      tags:
+        - sessions
+      parameters:
+        - name: model
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              notebook:
+                type: object
+                properties:
+                  path:
+                    type: string
+                    format: path
+                    description: new path for notebook
+      responses:
+        200:
+          description: Session
+          schema:
+            $ref: '#/definitions/Session'
+        400:
+          description: No data provided
+    delete:
+      summary: Delete a session
+      tags:
+        - sessions
+      responses:
+        204:
+          description: Session (and kernel) were deleted
+        410:
+          description: Kernel was deleted before the session, and the session was *not* deleted (TODO - check to make sure session wasn't deleted)
+  /sessions:
+    get:
+      summary: List available sessions
+      tags:
+        - sessions
+      responses:
+        200:
+          description: List of current sessions
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Session'
+    post:
+      summary: Create a new session, or return an existing session if a session for the notebook path already exists
+      tags:
+        - sessions
+      parameters:
+        - name: session
+          in: body
+          schema:
+            type: object
+            properties:
+              notebook:
+                type: object
+                required:
+                  - path
+                properties:
+                  path:
+                    type: string
+                    description: path to notebook file
+              kernel:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Kernel spec name, defaults to default kernel spec
+      responses:
+        201:
+          description: Session created or returned
+          schema:
+            $ref: '#/definitions/Session'
+          headers:
+            Location:
+              description: URL for session commands
+              type: string
+              format: url
+        501:
+          description: Kernel not available
+          schema:
+            type: object
+            description: error message
+            properties:
+              message:
+                type: string
+              short_message:
+                type: string
+
+  /kernels:
+    get:
+      summary: List the JSON data for all kernels that are currently running
+      tags:
+        - kernels
+      responses:
+        200:
+          description: List of currently-running kernel uuids
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Kernel'
+    post:
+      summary: Start a kernel and return the uuid
+      tags:
+        - kernels
+      parameters:
+        - name: name
+          in: body
+          description: Kernel spec name (defaults to default kernel spec for server)
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+      responses:
+        201:
+          description: Kernel started
+          headers:
+            Location:
+              description: URL for kernel commands
+              type: string
+              format: url
+  /kernels/{kernel}:
+    parameters:
+      - $ref: '#/parameters/kernel'
+    get:
+      summary: Get kernel information
+      tags:
+        - kernels
+      responses:
+        200:
+          description: Kernel information
+          schema:
+            $ref: '#/definitions/Kernel'
+    delete:
+      summary: Kill a kernel and delete the kernel id
+      tags:
+        - kernels
+      responses:
+        204:
+          description: Kernel deleted
+  /kernels/{kernel}/interrupt:
+    parameters:
+      - $ref: '#/parameters/kernel'
+    post:
+      summary: Interrupt a kernel
+      tags:
+        - kernels
+      responses:
+        204:
+          description: Kernel interrupted
+  /kernels/{kernel}/restart:
+    parameters:
+      - $ref: '#/parameters/kernel'
+    post:
+      summary: Restart a kernel
+      tags:
+        - kernels
+      responses:
+        200:
+          description: Kernel interrupted
+          headers:
+            Location:
+              description: URL for kernel commands
+              type: string
+              format: url
+          schema:
+            $ref: '#/definitions/Kernel'
+
+  /kernelspecs:
+    get:
+      summary: List kernel specs
+      tags:
+        - kernelspecs
+      responses:
+        200:
+          description: Kernel specs
+          schema:
+            type: object
+            properties:
+              default:
+                type: string
+                description: Default kernel name
+              kernelspecs:
+                type: array
+                items:
+                  $ref: '#/definitions/KernelSpec'
+  /kernelspecs/{kernel}:
+    parameters:
+      - $ref: '#/parameters/kernel'
+    get:
+      summary: Kernel information
+      tags:
+        - kernelspecs
+      responses:
+        200:
+          description: The contents of kernel.json
+          schema:
+            $ref: '#/definitions/KernelSpec'
+        404:
+          description: Kernel spec not found
+  /kernelspecs/{kernel}/{filename}:
+    get:
+      summary: Retrieve a file from the kernel directory
+      tags:
+        - kernelspecs
+      parameters:
+        - name: kernel
+          in: path
+          description: Kernel uuid
+          type: string
+          required: true
+        - name: filename
+          in: path
+          description: filename
+          type: string
+          required: true
+      responses:
+        200:
+          description: file
+
+definitions:
+  KernelSpec:
+    description: Kernel spec (contents of kernel.json)
+    properties:
+      name:
+        type: string
+        description: Unique name for kernel
+      spec:
+        $ref: '#/definitions/KernelSpecFile'
+        description: Kernel spec json file
+      resources:
+        type: object
+        properties:
+          kernel.js:
+            type: string
+            format: filename
+            description: path for kernel.js file
+          kernel.css:
+            type: string
+            format: filename
+            description: path for kernel.css file
+          logo-*:
+            type: string
+            format: filename
+            description: path for logo file.  Logo filenames are of the form `logo-widthxheight`
+  KernelSpecFile:
+    description: Kernel spec json file
+    required:
+      - argv
+      - display_name
+      - language
+    properties:
+      language:
+        type: string
+        description: The programming language which this kernel runs. This will be stored in notebook metadata.
+      argv:
+        type: array
+        description: A list of command line arguments used to start the kernel. The text `{connection_file}` in any argument will be replaced with the path to the connection file.
+        items:
+          type: string
+      display_name:
+        type: string
+        description: The kernel's name as it should be displayed in the UI. Unlike the kernel name used in the API, this can contain arbitrary unicode characters.
+      codemirror_mode:
+        type: string
+        description: Codemirror mode.  Can be a string *or* an valid Codemirror mode object.  This defaults to the string from the `language` property.
+      env:
+        type: object
+        description: A dictionary of environment variables to set for the kernel. These will be added to the current environment variables.
+        additionalProperties:
+          type: string
+      help_links:
+        type: array
+        description: Help items to be displayed in the help menu in the notebook UI.
+        items:
+          type: object
+          required:
+          - text
+          - url
+          properties:
+            text:
+              type: string
+              description: menu item link text
+            url:
+              type: string
+              format: URL
+              description: menu item link url
+  Kernel:
+    description: Kernel information
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: string
+        format: uuid
+        description: uuid of kernel
+      name:
+        type: string
+        description: kernel spec name
+  Session:
+    description: A session
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      notebook:
+        type: object
+        properties:
+          path:
+            type: string
+            description: path to notebook
+      kernel:
+        $ref: '#/definitions/Kernel'
+  Contents:
+    description: A contents object.  The content and format keys may be null if content is not contained.  If type is 'file', then the mimetype will be null.
+    type: object
+    required:
+      - type
+      - name
+      - path
+      - writable
+      - created
+      - last_modified
+      - mimetype
+      - format
+      - content
+    properties:
+      name:
+        type: string
+        description: Name of file or directory, equivalent to the last part of the path
+      path:
+        type: string
+        description: Full path for file or directory
+      type:
+        type: string
+        description: Type of content
+        enum:
+          - directory
+          - file
+          - notebook
+      writable:
+        type: boolean
+        description: indicates whether the requester has permission to edit the file
+      created:
+        type: string
+        description: Creation timestamp
+        format: dateTime
+      last_modified:
+        type: string
+        description: Last modified timestamp
+        format: dateTime
+      mimetype:
+        type: string
+        description: The mimetype of a file.  If content is not null, and type is 'file', this will contain the mimetype of the file, otherwise this will be null.
+      content:
+        type: string
+        description: The content, if requested (otherwise null).  Will be an array if type is 'directory'
+      format:
+        type: string
+        description: Format of content (one of null, 'text', 'base64', 'json')

--- a/rest_api.yaml
+++ b/rest_api.yaml
@@ -137,13 +137,13 @@ paths:
               path:
                 type: string
                 format: path
-                description: New path for file or directory.
+                description: New path for file or directory
       responses:
         200:
           description: Path updated
           headers:
             Location:
-              description: Updated URL for the file or directory.
+              description: Updated URL for the file or directory
               type: string
               format: url
         400:
@@ -157,6 +157,18 @@ paths:
               reason:
                 type: string
                 description: Explanation of error reason
+    delete:
+      summary: Delete a file in the given path
+      tags:
+        - contents
+      responses:
+        204:
+          description: File deleted
+          headers:
+            Location:
+              description: URL for the removed file
+              type: string
+              format: url
   /sessions/{session}:
     parameters:
       - $ref: '#/parameters/session'

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,164 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import utils = require('./utils');
+
+
+/**
+ * Configurable data section.
+ */
+export 
+class ConfigSection {
+
+  /**
+   * Create a config section.
+   */
+  constructor(sectionName: string, baseUrl: string) {
+    this._sectionName = sectionName;
+    this._baseUrl = baseUrl;
+    this._oneLoadFinished = false;
+    this._onLoaded = new Promise((resolve, reject) => {
+      this._finishFirstload = resolve;
+    });
+  }
+
+  /**
+   * Get the data for this section.
+   */
+  get data(): any {
+      return this._data;
+  }
+
+  /**
+   * Return the onLoaded Promise.
+   */
+  get onLoaded(): Promise<any> {
+      return this._onLoaded;
+  }
+
+  /**
+   * Get the url for this section.
+   */
+  get apiUrl(): string {
+    return utils.urlJoinEncode(this._baseUrl, 'api/config', this._sectionName);
+  }
+  
+  /**
+   * Retrieve the data for this section.
+   */
+  load(): Promise<any> {
+    return utils.ajaxRequest(this.apiUrl, {
+      method: "GET",
+      dataType: "json",
+    }).then((data) => {
+      this._data = data;
+      this._loadDone();
+      return data;
+    });
+  }
+  
+  /**
+   * Modify the config values stored. Update the local data immediately,
+   * send the change to the server, and use the updated data from the server
+   * when the reply comes.
+   */
+  update(newdata: any) : any {
+    utils.extend(this._data, newdata);  // true -> recursive update
+    
+    return utils.ajaxRequest(this.apiUrl, {
+      method : "PATCH",
+      data: JSON.stringify(newdata),
+      dataType : "json",
+      contentType: 'application/json',
+    }).then((data) => {
+      this._data = data;
+      this._loadDone();
+      return data;
+    });
+  }
+
+  /**
+   * Internal callback for handling load finished.
+   */
+  private _loadDone(): void {
+    if (!this._oneLoadFinished) {
+      this._oneLoadFinished = true;
+      this._finishFirstload();
+    }
+  }
+
+  private _sectionName = "unknown";
+  private _baseUrl = "unknown";
+  private _data: any = null;
+  private _onLoaded: Promise<any> = null;
+  private _oneLoadFinished = false;
+  private _finishFirstload: () => any = null;
+
+}
+
+
+/**
+ * Configurable object with defaults.
+ */
+export 
+class ConfigWithDefaults {
+  
+  /**
+   * Create a new config with defaults.
+   */
+  constructor(section: ConfigSection, defaults: any, classname: string) {
+    this._section = section;
+    this._defaults = defaults;
+    this._className = classname;
+  }
+  
+  /**
+   * Wait for config to have loaded, then get a value or the default.
+   */
+  get(key: string): any {
+    var that = this;
+    return this._section.onLoaded.then(function() {
+      return this._class_data()[key] || this._defaults[key]
+    });
+  }
+  
+  /**
+   * Return a config value. If config is not yet loaded, return the default
+   * instead of waiting for it to load.
+   */
+  getSync(key: string): any {
+    return this._classData()[key] || this._defaults[key];
+  }
+  
+  /**
+   * Set a config value. Send the update to the server, and change our
+   * local copy of the data immediately.
+   */
+  set(key: string, value: any): Promise<any> {
+     var d: any = {};
+     d[key] = value;
+     if (this._className) {
+      var d2: any = {};
+      d2[this._className] = d;
+      return this._section.update(d2);
+    } else {
+      return this._section.update(d);
+    }
+  }
+
+  /**
+   * Get data from the Section with our classname, if available.
+   * If we have no classname, get all of the data in the Section
+   */
+  private _classData(): any {
+    if (this._className) {
+      return this._section.data[this._className] || {};
+    } else {
+      return this._section.data
+    }
+  }
+
+  private _section: ConfigSection = null;
+  private _defaults: any = null;
+  private _className = "unknown";
+}

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -195,7 +195,8 @@ class Contents implements IContents {
     };
     var url = this._getUrl(path);
     return utils.ajaxRequest(url, settings).then((success: IAjaxSuccess): IContentsModel => {
-      if (success.xhr.status !== 200) {
+      // will return 200 for an existing file and 201 for a new file
+      if (success.xhr.status !== 200 && success.xhr.status !== 201) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
       validateContentsModel(success.data);

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -13,6 +13,7 @@ var SERVICE_CONTENTS_URL = 'api/contents';
 /**
  * Options for a contents object.
  */
+export
 interface IContentsOpts {
   type?: string;
   format?: string;

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -4,6 +4,15 @@
 import utils = require('./utils');
 
 
+/**
+ * The url for the contents service.
+ */
+var SERVICE_CONTENTS_URL = 'api/contents';
+
+
+/**
+ * Options for a contents object.
+ */
 export 
 interface IContentsOpts {
   type?: string;
@@ -23,7 +32,7 @@ class Contents {
    * Create a new contents object.
    */
   constructor(baseUrl: string) {
-    this._baseUrl = baseUrl;
+    this._apiUrl = utils.urlJoinEncode(baseUrl, SERVICE_CONTENTS_URL);
   }
 
   /**
@@ -35,7 +44,7 @@ class Contents {
       method : "GET",
       dataType : "json",
     };
-    var url = this.apiUrl(path);
+    var url = this._getUrl(path);
     var params: IContentsOpts = {};
     if (options.type) { params.type = options.type; }
     if (options.format) { params.format = options.format; }
@@ -57,7 +66,7 @@ class Contents {
       contentType: 'application/json',
       dataType : "json",
     };
-    return utils.ajaxRequest(this.apiUrl(path), settings);
+    return utils.ajaxRequest(this._getUrl(path), settings);
   }
 
   /**
@@ -68,7 +77,7 @@ class Contents {
       method : "DELETE",
       dataType : "json",
     };
-    var url = this.apiUrl(path);
+    var url = this._getUrl(path);
     return utils.ajaxRequest(url, settings).catch(
       // Translate certain errors to more specific ones.
       function(error) {
@@ -93,7 +102,7 @@ class Contents {
       dataType: "json",
       contentType: 'application/json',
     };
-    var url = this.apiUrl(path);
+    var url = this._getUrl(path);
     return utils.ajaxRequest(url, settings);
   }
 
@@ -107,7 +116,7 @@ class Contents {
       data : JSON.stringify(model),
       contentType: 'application/json',
     };
-    var url = this.apiUrl(path);
+    var url = this._getUrl(path);
     return utils.ajaxRequest(url, settings);
   }
   
@@ -122,7 +131,7 @@ class Contents {
       contentType: 'application/json',
       dataType : "json",
     };
-    var url = this.apiUrl(to_dir);
+    var url = this._getUrl(to_dir);
     return utils.ajaxRequest(url, settings);
   }
 
@@ -134,7 +143,7 @@ class Contents {
       method : "POST",
       dataType : "json",
     };
-    var url = this.apiUrl(path, 'checkpoints');
+    var url = this._getUrl(path, 'checkpoints');
     return utils.ajaxRequest(url, settings);
   }
 
@@ -146,7 +155,7 @@ class Contents {
       method : "GET",
       dataType: "json",
     };
-    var url = this.apiUrl(path, 'checkpoints');
+    var url = this._getUrl(path, 'checkpoints');
     return utils.ajaxRequest(url, settings);
   }
 
@@ -157,7 +166,7 @@ class Contents {
     var settings = {
       method : "POST",
     };
-    var url = this.apiUrl(path, 'checkpoints', checkpoint_id);
+    var url = this._getUrl(path, 'checkpoints', checkpoint_id);
     return utils.ajaxRequest(url, settings);
   }
 
@@ -168,7 +177,7 @@ class Contents {
     var settings = {
       method : "DELETE",
     };
-    var url = this.apiUrl(path, 'checkpoints', checkpoint_id);
+    var url = this._getUrl(path, 'checkpoints', checkpoint_id);
     return utils.ajaxRequest(url, settings);
   }
 
@@ -182,11 +191,11 @@ class Contents {
   /**
    * Get an REST url for this file given a path.
    */
-  private apiUrl(...args: string[]): string {
-    var url_parts = [this._baseUrl, 'api/contents'].concat(
+  private _getUrl(...args: string[]): string {
+    var url_parts = [this._apiUrl].concat(
                 Array.prototype.slice.apply(args));
     return utils.urlJoinEncode.apply(null, url_parts);
   }
 
-  private _baseUrl = "unknown";
+  private _apiUrl = "unknown";
 }

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -13,7 +13,6 @@ var SERVICE_CONTENTS_URL = 'api/contents';
 /**
  * Options for a contents object.
  */
-export 
 interface IContentsOpts {
   type?: string;
   format?: string;

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -1,0 +1,192 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import utils = require('./utils');
+
+
+export 
+interface IContentsOpts {
+  type?: string;
+  format?: string;
+  content?: any;
+  ext?: string;
+}
+
+/**
+ * A contents handle passing file operations to the back-end.  
+ * This includes checkpointing with the normal file operations.
+ */
+export 
+class Contents {
+
+  /**
+   * Create a new contents object.
+   */
+  constructor(baseUrl: string) {
+    this._baseUrl = baseUrl;
+  }
+
+  /**
+   * Get a file.
+   */
+  get(path: string, options: IContentsOpts): Promise<any> {
+     // We do the call with settings so we can set cache to false.
+    var settings = {
+      method : "GET",
+      dataType : "json",
+    };
+    var url = this.apiUrl(path);
+    var params: IContentsOpts = {};
+    if (options.type) { params.type = options.type; }
+    if (options.format) { params.format = options.format; }
+    if (options.content === false) { params.content = '0'; }
+    return utils.ajaxRequest(url + utils.jsonToQueryString(params), settings);
+  }
+
+  /**
+   * Create a new untitled file or directory in the specified directory path.
+   */
+  newUntitled(path: string, options: IContentsOpts): Promise<any> {
+    var data = JSON.stringify({
+      ext: options.ext,
+      type: options.type
+    });
+    var settings = {
+      method : "POST",
+      data: data,
+      contentType: 'application/json',
+      dataType : "json",
+    };
+    return utils.ajaxRequest(this.apiUrl(path), settings);
+  }
+
+  /**
+   * Delete a file.
+   */
+  delete(path: string): Promise<any> {
+    var settings = {
+      method : "DELETE",
+      dataType : "json",
+    };
+    var url = this.apiUrl(path);
+    return utils.ajaxRequest(url, settings).catch(
+      // Translate certain errors to more specific ones.
+      function(error) {
+        // TODO: update IPEP27 to specify errors more precisely, so
+        // that error types can be detected here with certainty.
+        if (error.xhr.status === 400) {
+          throw new Error('Directory not found');
+        }
+        throw error;
+      }
+    );
+  }
+
+  /**
+   * Rename a file.
+   */
+  rename(path: string, new_path: string): Promise<any> {
+    var data = {path: new_path};
+    var settings = {
+      method : "PATCH",
+      data : JSON.stringify(data),
+      dataType: "json",
+      contentType: 'application/json',
+    };
+    var url = this.apiUrl(path);
+    return utils.ajaxRequest(url, settings);
+  }
+
+  /**
+   * Save a file.
+   */
+  save(path: string, model: any): Promise<any> {
+    var settings = {
+      method : "PUT",
+      dataType: "json",
+      data : JSON.stringify(model),
+      contentType: 'application/json',
+    };
+    var url = this.apiUrl(path);
+    return utils.ajaxRequest(url, settings);
+  }
+  
+  /**
+   * Copy a file into a given directory via POST
+   * The server will select the name of the copied file.
+   */
+  copy(from_file: string, to_dir: string): Promise<any> {
+    var settings = {
+      method: "POST",
+      data: JSON.stringify({copy_from: from_file}),
+      contentType: 'application/json',
+      dataType : "json",
+    };
+    var url = this.apiUrl(to_dir);
+    return utils.ajaxRequest(url, settings);
+  }
+
+  /**
+   * Create a checkpoint for a file.
+   */
+  createCheckpoint(path: string): Promise<any> {
+    var settings = {
+      method : "POST",
+      dataType : "json",
+    };
+    var url = this.apiUrl(path, 'checkpoints');
+    return utils.ajaxRequest(url, settings);
+  }
+
+  /** 
+   * List available checkpoints for a file.
+   */
+  listCheckpoints(path: string): Promise<any> {
+    var settings = {
+      method : "GET",
+      dataType: "json",
+    };
+    var url = this.apiUrl(path, 'checkpoints');
+    return utils.ajaxRequest(url, settings);
+  }
+
+  /**
+   * Restore a file to a known checkpoint state.
+   */
+  restoreCheckpoint(path: string, checkpoint_id: string): Promise<any> {
+    var settings = {
+      method : "POST",
+    };
+    var url = this.apiUrl(path, 'checkpoints', checkpoint_id);
+    return utils.ajaxRequest(url, settings);
+  }
+
+  /**
+   * Delete a checkpoint for a file.
+   */
+  deleteCheckpoint(path: string, checkpoint_id: string): Promise<any> {
+    var settings = {
+      method : "DELETE",
+    };
+    var url = this.apiUrl(path, 'checkpoints', checkpoint_id);
+    return utils.ajaxRequest(url, settings);
+  }
+
+  /**
+   * List notebooks and directories at a given path.
+   */
+  listContents(path: string): Promise<any> {
+    return this.get(path, {type: 'directory'});
+  }
+
+  /**
+   * Get an REST url for this file given a path.
+   */
+  private apiUrl(...args: string[]): string {
+    var url_parts = [this._baseUrl, 'api/contents'].concat(
+                Array.prototype.slice.apply(args));
+    return utils.urlJoinEncode.apply(null, url_parts);
+  }
+
+  private _baseUrl = "unknown";
+}

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -22,6 +22,7 @@ interface IContentsOpts {
   format?: string;
   content?: any;
   ext?: string;
+  name?: string;
 }
 
 
@@ -112,17 +113,19 @@ class Contents implements IContents {
   /**
    * Create a new untitled file or directory in the specified directory path.
    */
-  newUntitled(path: string, options: IContentsOpts): Promise<IContentsModel> {
-    var data = JSON.stringify({
-      ext: options.ext,
-      type: options.type
-    });
-    var settings = {
-      method : "POST",
-      data: data,
-      contentType: 'application/json',
-      dataType : "json",
+  newUntitled(path: string, options?: IContentsOpts): Promise<IContentsModel> {
+    var settings: utils.IAjaxSettings = {
+        method : "POST",
+        dataType : "json",
     };
+    if (options) {
+      var data = JSON.stringify({
+        ext: options.ext,
+        type: options.type
+      });
+      settings.data = data;
+      settings.contentType = 'application/json';
+    }
     var url = this._getUrl(path);
     return utils.ajaxRequest(url, settings).then((success: IAjaxSuccess): IContentsModel => {
       if (success.xhr.status !== 201) {
@@ -183,7 +186,7 @@ class Contents implements IContents {
   /**
    * Save a file.
    */
-  save(path: string, model: any): Promise<IContentsModel> {
+  save(path: string, model: IContentsOpts): Promise<IContentsModel> {
     var settings = {
       method : "PUT",
       dataType: "json",
@@ -192,7 +195,7 @@ class Contents implements IContents {
     };
     var url = this._getUrl(path);
     return utils.ajaxRequest(url, settings).then((success: IAjaxSuccess): IContentsModel => {
-      if (success.xhr.status !== 201) {
+      if (success.xhr.status !== 200) {
         throw Error('Invalid Status: ' + success.xhr.status);
       }
       validateContentsModel(success.data);
@@ -295,7 +298,7 @@ class Contents implements IContents {
     });
   }
 
-  /**
+  /** 
    * List notebooks and directories at a given path.
    */
   listContents(path: string): Promise<IContentsModel> {

--- a/src/contents.ts
+++ b/src/contents.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import utils = require('./utils');
-
+import Token = phosphor.di.Token;
 
 /**
  * The url for the contents service.
@@ -21,12 +21,31 @@ interface IContentsOpts {
   ext?: string;
 }
 
+
+/**
+ * Interface that a content manager should implement.
+ **/
+export 
+interface IContents {
+  get(path: string, type: string, options: IContentsOpts): Promise<any>;
+  newUntitled(path: string, options: IContentsOpts): Promise<any>;
+  delete(path: string): void;
+  rename(path: string, newPath: string): Promise<any>;
+  save(path: string, model: any): Promise<any>;
+  listContents(path: string): Promise<any>;
+  copy(path: string, toDir: string): Promise<any>;
+  createCheckpoint(path: string): Promise<any>;
+  restoreCheckpoint(path: string, checkpointID: string): Promise<any>;
+  listCheckpoints(path: string): Promise<any>;
+}
+
+
 /**
  * A contents handle passing file operations to the back-end.  
  * This includes checkpointing with the normal file operations.
  */
 export 
-class Contents {
+class Contents implements IContents {
 
   /**
    * Create a new contents object.
@@ -94,8 +113,8 @@ class Contents {
   /**
    * Rename a file.
    */
-  rename(path: string, new_path: string): Promise<any> {
-    var data = {path: new_path};
+  rename(path: string, newPath: string): Promise<any> {
+    var data = {path: newPath};
     var settings = {
       method : "PATCH",
       data : JSON.stringify(data),
@@ -124,14 +143,14 @@ class Contents {
    * Copy a file into a given directory via POST
    * The server will select the name of the copied file.
    */
-  copy(from_file: string, to_dir: string): Promise<any> {
+  copy(fromFile: string, toDir: string): Promise<any> {
     var settings = {
       method: "POST",
-      data: JSON.stringify({copy_from: from_file}),
+      data: JSON.stringify({copy_from: fromFile}),
       contentType: 'application/json',
       dataType : "json",
     };
-    var url = this._getUrl(to_dir);
+    var url = this._getUrl(toDir);
     return utils.ajaxRequest(url, settings);
   }
 
@@ -162,22 +181,22 @@ class Contents {
   /**
    * Restore a file to a known checkpoint state.
    */
-  restoreCheckpoint(path: string, checkpoint_id: string): Promise<any> {
+  restoreCheckpoint(path: string, checkpointID: string): Promise<any> {
     var settings = {
       method : "POST",
     };
-    var url = this._getUrl(path, 'checkpoints', checkpoint_id);
+    var url = this._getUrl(path, 'checkpoints', checkpointID);
     return utils.ajaxRequest(url, settings);
   }
 
   /**
    * Delete a checkpoint for a file.
    */
-  deleteCheckpoint(path: string, checkpoint_id: string): Promise<any> {
+  deleteCheckpoint(path: string, checkpointID: string): Promise<any> {
     var settings = {
       method : "DELETE",
     };
-    var url = this._getUrl(path, 'checkpoints', checkpoint_id);
+    var url = this._getUrl(path, 'checkpoints', checkpointID);
     return utils.ajaxRequest(url, settings);
   }
 
@@ -199,3 +218,10 @@ class Contents {
 
   private _apiUrl = "unknown";
 }
+
+
+/**
+ * The interface token for IContents.
+ */
+export
+var IContents = new Token<IContents>('IContents');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,7 +120,7 @@ function jsonToQueryString(json: any): string {
 export
 interface IAjaxSetttings {
   method: string;
-  dataType: string;
+  dataType?: string;
   contentType?: string;
   data?: any;
 }
@@ -163,7 +163,8 @@ function ajaxRequest(url: string, settings: IAjaxSetttings): Promise<any> {
     }
     req.onload = () => {
       var response = req.response;
-      if (settings.dataType === 'json') {
+      if (settings.hasOwnProperty('dataType') && 
+          settings.dataType === 'json') {
         response = JSON.parse(req.response);
       }
       resolve({data: response, statusText: req.statusText, xhr: req});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,7 +118,7 @@ function jsonToQueryString(json: any): string {
  * Input settings for an AJAX request.
  */
 export
-interface IAjaxSetttings {
+interface IAjaxSettings {
   method: string;
   dataType?: string;
   contentType?: string;
@@ -154,7 +154,7 @@ interface IAjaxError {
  * http://www.html5rocks.com/en/tutorials/es6/promises/#toc-promisifying-xmlhttprequest
  */
 export
-function ajaxRequest(url: string, settings: IAjaxSetttings): Promise<any> {
+function ajaxRequest(url: string, settings: IAjaxSettings): Promise<any> {
   return new Promise((resolve, reject) => {
     var req = new XMLHttpRequest();
     req.open(settings.method, url);


### PR DESCRIPTION
Adds the Contents and Config services, as well as a swagger REST API  [definition](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/blink1073/phosphor-notebook-1/other-services/rest_api.yaml#!/contents).

Follows https://github.com/ipython/ipython/wiki/IPEP-27:-Contents-Service and https://github.com/jupyter/notebook/blob/master/notebook/services/contents/handlers.py.
